### PR TITLE
Custom button class

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,8 +45,9 @@ You can also pass in the message into a named slot. This way you can for example
 | prop | default | type | description
 |---|---|---|---|
 | buttonText | 'Got It!' | String | 🔘 Well, its the button text
-| buttonLink|  | String | Link to more infos
-| buttonLinkText| 'More info' | String | Label of link button
+| buttonLink |  | String | Link to more infos
+| buttonLinkText | 'More info' | String | Label of link button
+| buttonClass | 'Cookie__button' | String | Custom class name for buttons
 | message | 'This website uses cookies to ensure you get the best experience on our website.' | String | Your message in the content area
 | theme | 'base' | String | Selected theme. You can also create a custom one
 | position | 'bottom' | String | Possible positions are `bottom` or `top`

--- a/src/components/CookieLaw.vue
+++ b/src/components/CookieLaw.vue
@@ -5,8 +5,8 @@
         <slot name="message">{{ message }}</slot>
       </div>
       <div class="Cookie__buttons">
-        <a :href="buttonLink" v-if="buttonLink" class="Cookie__button">{{ buttonLinkText }}</a>
-        <div class="Cookie__button" @click="accept">{{ buttonText }}</div>
+        <a :href="buttonLink" v-if="buttonLink" :class="[buttonClass ? buttonClass : 'Cookie__button']">{{ buttonLinkText }}</a>
+        <div :class="[buttonClass ? buttonClass : 'Cookie__button']" @click="accept">{{ buttonText }}</div>
       </div>
     </div>
   </transition>
@@ -53,6 +53,9 @@
       transitionName: {
         type: String,
         default: 'slideFromBottom'
+      },
+      buttonClass: {
+        type: String
       }
     },
     data () {

--- a/src/components/CookieLaw.vue
+++ b/src/components/CookieLaw.vue
@@ -5,8 +5,8 @@
         <slot name="message">{{ message }}</slot>
       </div>
       <div class="Cookie__buttons">
-        <a :href="buttonLink" v-if="buttonLink" :class="[buttonClass ? buttonClass : 'Cookie__button']">{{ buttonLinkText }}</a>
-        <div :class="[buttonClass ? buttonClass : 'Cookie__button']" @click="accept">{{ buttonText }}</div>
+        <a :href="buttonLink" v-if="buttonLink" :class="buttonClass">{{ buttonLinkText }}</a>
+        <div :class="buttonClass" @click="accept">{{ buttonText }}</div>
       </div>
     </div>
   </transition>
@@ -55,7 +55,8 @@
         default: 'slideFromBottom'
       },
       buttonClass: {
-        type: String
+        type: String,
+        default: 'Cookie__button'
       }
     },
     data () {


### PR DESCRIPTION
Different CSS libraries make use of different class names for styling buttons. This PR adds the option to change the default button class by introducing an optional prop called `buttonClass`. 

To override the default button class _Cookie__button_, simply pass the prop `buttonClass="myButtonClass"` to the component.