### PR TITLE
Add router-link support for buttonLink prop

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ You can also pass in the message into a named slot. This way you can for example
 | prop | default | type | description
 |---|---|---|---|
 | buttonText | 'Got It!' | String | 🔘 Well, its the button text
-| buttonLink |  | String | Link to more infos
+| buttonLink |  | String\|Object | Link to more infos. Simple href or a [vue-router](https://github.com/vuejs/vue-router) Location object
 | buttonLinkText | 'More info' | String | Label of link button
 | buttonClass | 'Cookie__button' | String | Custom class name for buttons
 | message | 'This website uses cookies to ensure you get the best experience on our website.' | String | Your message in the content area

--- a/src/components/CookieLaw.vue
+++ b/src/components/CookieLaw.vue
@@ -5,7 +5,8 @@
         <slot name="message">{{ message }}</slot>
       </div>
       <div class="Cookie__buttons">
-        <a :href="buttonLink" v-if="buttonLink" :class="buttonClass">{{ buttonLinkText }}</a>
+        <a :href="buttonLink" v-if="externalButtonLink" :class="buttonClass">{{ buttonLinkText }}</a>
+        <router-link :to="buttonLink" v-if="internalButtonLink" :class="buttonClass">{{ buttonLinkText }}</router-link>
         <div :class="buttonClass" @click="accept">{{ buttonText }}</div>
       </div>
     </div>
@@ -21,7 +22,8 @@
         default: 'Got it!'
       },
       buttonLink: {
-        type: String
+        type: [String, Object],
+        required: false
       },
       buttonLinkText: {
         type: String,
@@ -72,6 +74,12 @@
       },
       cookieTheme () {
         return `Cookie--${this.theme}`
+      },
+      externalButtonLink () {
+        return typeof this.buttonLink === 'string' && this.buttonLink.length
+      },
+      internalButtonLink () {
+        return typeof this.buttonLink === 'object' && this.buttonLink != null && Object.keys(this.buttonLink).length
       }
     },
     created () {


### PR DESCRIPTION
Enables the user to pass a [vue-router](https://github.com/vuejs/vue-router) Location object to the `buttonLink` property.