### PR TITLE
add slot and close method

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,26 @@ You can also pass in the message into a named slot. This way you can for example
 </cookie-law>
 ```
 
+## Scoped Slot
+
+For a more complex layout use the scoped slot
+```html
+<cookie-law>
+  <div slot-scope="props">
+    <button class="skew" @click="props.accept"><span>I accept</span></button>
+    <p>
+      This site uses 🍪
+    </p>
+    <button class="skew" @click="props.close"><span>Ignore me</span></button>
+  </div>
+
+</cookie-law>
+```
+| methods | description |
+|---|---|
+| accept | Closes the cookie disclaimer and saves to localStorage |
+| close | Only closes the cookie disclaimer. The disclaimer will reappear on the next page load. |
+
 ## Props
 | prop | default | type | description
 |---|---|---|---|

--- a/src/App.vue
+++ b/src/App.vue
@@ -10,7 +10,18 @@
       <option value="dark-lime--rounded">Dark Lime Round</option>
       <option value="royal--rounded">Royal Round</option>
     </select>
-    <cookie-law :theme="theme"></cookie-law>
+    <cookie-law :theme="theme">
+      <div slot-scope="props" class="container">
+
+        <button @click="props.accept"><span>I accept</span></button>
+        <p>
+          Lorem ipsum, dolor sit amet consectetur adipisicing elit. Ex, hic?
+        </p>
+
+        <button @click="props.close"><span>Close</span></button>
+      </div>
+
+    </cookie-law>
   </div>
 </template>
 
@@ -44,5 +55,26 @@ select {
   width: 400px;
   height: 40px;
   font-size: 18px;
+}
+
+button {
+  background: rebeccapurple;
+  color: #fff;
+  font-size: 0.875rem;
+  font-weight: 700;
+  text-transform: uppercase;
+  border-radius: 8px 0;
+  transform: skew(-20deg);
+  padding: 0.2rem 1rem;
+}
+
+button span {
+  display: inline-block;
+  transform: skew(20deg);
+}
+
+.container {
+  width: 100%;
+  text-align: center;
 }
 </style>

--- a/src/App.vue
+++ b/src/App.vue
@@ -10,15 +10,16 @@
       <option value="dark-lime--rounded">Dark Lime Round</option>
       <option value="royal--rounded">Royal Round</option>
     </select>
+    <cookie-law :theme="theme" position="top" transition-name="fade"></cookie-law>
     <cookie-law :theme="theme">
       <div slot-scope="props" class="container">
 
-        <button @click="props.accept"><span>I accept</span></button>
+        <button class="skew" @click="props.accept"><span>I accept</span></button>
         <p>
           Lorem ipsum, dolor sit amet consectetur adipisicing elit. Ex, hic?
         </p>
 
-        <button @click="props.close"><span>Close</span></button>
+        <button class="skew" @click="props.close"><span>Close</span></button>
       </div>
 
     </cookie-law>
@@ -48,7 +49,11 @@ export default {
   -moz-osx-font-smoothing: grayscale;
   text-align: center;
   color: #2c3e50;
+  height: 100vh;
   margin-top: 60px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
 }
 
 select {
@@ -57,7 +62,7 @@ select {
   font-size: 18px;
 }
 
-button {
+.skew {
   background: rebeccapurple;
   color: #fff;
   font-size: 0.875rem;
@@ -68,7 +73,7 @@ button {
   padding: 0.2rem 1rem;
 }
 
-button span {
+.skew span {
   display: inline-block;
   transform: skew(20deg);
 }

--- a/src/components/CookieLaw.vue
+++ b/src/components/CookieLaw.vue
@@ -1,14 +1,16 @@
 <template>
   <transition appear :name="transitionName">
     <div class="Cookie" :class="[containerPosition, cookieTheme]" v-if="isOpen">
-      <div class="Cookie__content">
-        <slot name="message">{{ message }}</slot>
-      </div>
-      <div class="Cookie__buttons">
-        <a :target="target" :href="buttonLink" v-if="externalButtonLink" :class="buttonClass">{{ buttonLinkText }}</a>
-        <router-link :to="buttonLink" v-if="internalButtonLink" :class="buttonClass">{{ buttonLinkText }}</router-link>
-        <button :class="buttonClass" @click="accept">{{ buttonText }}</button>
-      </div>
+      <slot :accept="accept" :close="close">
+        <div class="Cookie__content">
+          <slot name="message">{{ message }}</slot>
+        </div>
+        <div class="Cookie__buttons">
+          <a :target="target" :href="buttonLink" v-if="externalButtonLink" :class="buttonClass">{{ buttonLinkText }}</a>
+          <router-link :to="buttonLink" v-if="internalButtonLink" :class="buttonClass">{{ buttonLinkText }}</router-link>
+          <button :class="buttonClass" @click="accept">{{ buttonText }}</button>
+        </div>
+      </slot>
     </div>
   </transition>
 </template>
@@ -128,6 +130,10 @@
         this.setVisited()
         this.isOpen = false
         this.$emit('accept')
+      },
+
+      close () {
+        this.isOpen = false
       }
     }
   }


### PR DESCRIPTION
Add the ability to completely create your own markup inside the cookie container with a scoped slot.

New method `close()` closes the cookie disclaimer without saving things to localStorage.