### PR TITLE
added nowrap to button

### DIFF
--- a/src/components/CookieLaw.vue
+++ b/src/components/CookieLaw.vue
@@ -201,6 +201,7 @@
   .Cookie__button {
     cursor: pointer;
     align-self: center;
+    white-space: nowrap;
   }
 
   @mixin generateTheme($theme, $backgroundColor, $fontColor, $buttonBackgroundColor, $buttonFontColor: #fff, $buttonRadius: 0) {


### PR DESCRIPTION
Hi.

In my opinion, the `Cookie_button` should have the `white-space: nowrap;` style in order to prevent multi line "Got it!" button, when the cookie message is very long.

Before:
![image](https://user-images.githubusercontent.com/2781191/52949072-8fea4600-337b-11e9-9dc3-f021c3f089b9.png)

After:
![image](https://user-images.githubusercontent.com/2781191/52949095-9d9fcb80-337b-11e9-904e-252ed09ad949.png)
