### PR TITLE
feat: Add prop to set cookie options

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,6 +78,7 @@ For a more complex layout use the **scoped slot**
 | position | 'bottom' | String | Possible positions are `bottom` or `top`
 | transitionName | 'slideFromBottom' | String | Enter and leave transitions. Currently supported `slideFromBottom`, `slideFromTop`, `fade`
 | storageType | 'localStorage' | String | Type of storage, where to store 'cookies:accept': true. Can be `localStorage` (default) or `cookies`. If LocalStorage is unsupported, then used Cookies.
+| cookieOptions | {} | Object | (Optional) The cookieOptions parameter is an object. And its property can be a valid cookie option, such as `path`, `domain`, `expires` / `max-age`, `samesite` or `secure`. See [tiny-cookie docs](https://github.com/Alex1990/tiny-cookie#setkey-value-options) for details.
 
 ## Events
 

--- a/src/components/CookieLaw.vue
+++ b/src/components/CookieLaw.vue
@@ -81,6 +81,11 @@
       storageType: {
         type: String,
         default: STORAGE_TYPES.local
+      },
+      cookieOptions: {
+        type: Object,
+        default: () => {},
+        required: false
       }
     },
     data () {
@@ -132,7 +137,7 @@
         if (this.canUseLocalStorage) {
           localStorage.setItem(this.storageName, true)
         } else {
-          Cookie.set(this.storageName, true)
+          Cookie.set(this.storageName, true, this.cookieOptions)
         }
       },
       getVisited () {

--- a/test/unit/specs/CookieLaw.spec.js
+++ b/test/unit/specs/CookieLaw.spec.js
@@ -1,6 +1,6 @@
 import Vue from 'vue'
 import CookieLaw from '@/components/CookieLaw'
-// import * as Cookie from 'tiny-cookie'
+import * as Cookie from 'tiny-cookie'
 
 describe('CookieLaw.vue', () => {
   it('should render correct contents', () => {
@@ -30,6 +30,32 @@ describe('CookieLaw.vue', () => {
     const vm = new Constructor({ propsData: { buttonLink: 'link', buttonLinkNewTab: true } }).$mount()
     expect(vm.$el.querySelector('.Cookie__buttons > a').getAttribute('target'))
       .to.equal('_blank')
+  })
+  it('should set cookie when domain prop is not set', () => {
+    const Constructor = Vue.extend(CookieLaw)
+    const vm = new Constructor({ propsData: { storageType: 'cookies' } }).$mount()
+
+    expect(Cookie.get('cookie:accepted')).to.equal(null)
+
+    vm.$el.querySelector('.Cookie__button').click()
+
+    expect(Cookie.get('cookie:accepted')).to.equal('true')
+
+    Cookie.remove('cookie:accepted')
+  })
+  it('should set cookie when domain prop set', () => {
+    const Constructor = Vue.extend(CookieLaw)
+    const vm = new Constructor({
+      propsData: { storageType: 'cookies', cookieOptions: { domain: 'localhost' } }
+    }).$mount()
+
+    expect(Cookie.get('cookie:accepted')).to.equal(null)
+
+    vm.$el.querySelector('.Cookie__button').click()
+
+    expect(Cookie.get('cookie:accepted')).to.equal('true')
+
+    Cookie.remove('cookie:accepted', { domain: 'localhost' })
   })
   // it('should set a cookie when localstorage is not available', () => {
   //   const Constructor = Vue.extend(CookieLaw)


### PR DESCRIPTION
Hey, I'm opening this PR based on https://github.com/apertureless/vue-cookie-law/issues/48

I created a computed property, which could be used to support various props down the road if that makes sense.